### PR TITLE
API: Action & team creation

### DIFF
--- a/src/api/controllers/ActionController.js
+++ b/src/api/controllers/ActionController.js
@@ -1,9 +1,51 @@
+const Action = require("../models/ActionModel");
+
 module.exports = {
   approveAction: (req, res) => {},
 
   cancelAction: (req, res) => {},
 
-  createAction: (req, res) => {},
+  createAction: (req, res) => {
+    const name = req.body.name;
+
+    Action.find({ name })
+      .then(action => {
+        if (action.length == 1) {
+          return res.status(409).json({
+            message: "Name not available."
+          });
+        }
+
+        action = new Action();
+        if (req.body.organizer) {
+          action[`organizer`][`organizerId`] = req.userData.userId;
+          action[`organizer`][`isTeam`] = req.body.organizer.isTeam;
+        }
+
+        if (req.body.location) {
+          action[`location`][`name`] = req.body.location.name;
+          action[`location`][`coordinates`] = req.body.location.coordinates;
+        }
+
+        Action.schema.eachPath(path => {
+          if (req.body[path]) {
+            action[`${path}`] = req.body[path];
+          }
+        });
+
+        action
+          .save()
+          .then(() => res.status(201).send())
+          .catch(err => {
+            console.error(`Error during action save():\n${err}`);
+            res.status(400).json(err);
+          });
+      })
+      .catch(err => {
+        console.error(`Error during action find():\n${err}`);
+        res.status(500).send();
+      });
+  },
 
   declineAction: (req, res) => {},
 

--- a/src/api/controllers/ActionController.js
+++ b/src/api/controllers/ActionController.js
@@ -1,55 +1,120 @@
 const Action = require("../models/ActionModel");
+const Team = require("../models/TeamModel");
+const Category = require("../models/CategoryModel");
 
 module.exports = {
   approveAction: (req, res) => {},
 
   cancelAction: (req, res) => {},
 
+  changePhoto: (req, res) => {},
+
   createAction: (req, res) => {
-    const name = req.body.name;
+    const action = new Action();
+    var promises = [];
 
-    Action.find({ name })
-      .then(action => {
-        if (action.length == 1) {
-          return res.status(409).json({
-            message: "Name not available."
+    if (req.body.name) {
+      action[`name`] = req.body.name;
+    } else {
+      return res.status(400).json({ error: "Fiend `name` is required" });
+    }
+
+    if (req.body.date) {
+      action[`date`] = req.body.date;
+    } else {
+      return res.status(400).json({ error: "Field `date` is required" });
+    }
+
+    action[`description`] = req.body.description || null;
+
+    if (req.body.categories) {
+      const categories = req.body.categories;
+      promises.push(
+        Category.find({ name: { $in: categories } }).then((categories) => {
+          categories.forEach((category) => {
+            action[`categories`].push(category._id);
           });
+        })
+      );
+    }
+
+    if (req.body.organizer) {
+      if (!req.body.organizer.team) {
+        action[`organizer`][`userId`] = req.userData.userId;
+      } else {
+        promises.push(
+          Team.findOne({ name: req.body.organizer.team }).then((team) => {
+            if (team) {
+              action[`organizer`][`teamId`] = team._id;
+            } else {
+              return res.status(400).json({ error: "Invalid organizer" });
+            }
+          })
+        );
+      }
+    } else {
+      return res.status(400).json({ error: "Field `organizer` is required" });
+    }
+
+    if (req.body.location) {
+      const coordinates = req.body.location.coordinates;
+
+      if (req.body.location.name) {
+        action[`location`][`name`] = req.body.location.name;
+      } else {
+        return res
+          .status(400)
+          .json({ error: "Field `location.name` is required" });
+      }
+
+      if (coordinates) {
+        if (coordinates.length == 2) {
+          action[`location`][`coordinates`] = coordinates;
+        } else {
+          return res.status(400).json({ error: "Invalid coordinates" });
         }
+      } else {
+        return res
+          .status(400)
+          .json({ error: "Field `location.coordinates is required" });
+      }
+    }
 
-        action = new Action();
-        if (req.body.organizer) {
-          action[`organizer`][`organizerId`] = req.userData.userId;
-          action[`organizer`][`isTeam`] = req.body.organizer.isTeam;
-        }
+    Promise.all(promises).then(() => {
+      action
+        .save()
+        .then(() => {
+          return res.status(201).send(action);
+        })
+        .catch((err) => {
+          if (err.name == "ValidationError") {
+            if (err.errors.date) {
+              if (err.errors.date.kind == "Date") {
+                return res.status(400).json({ error: "Date is invalid" });
+              }
+            }
 
-        if (req.body.location) {
-          action[`location`][`name`] = req.body.location.name;
-          action[`location`][`coordinates`] = req.body.location.coordinates;
-        }
+            if (err.errors.name) {
+              if (err.errors.name.kind == "unique") {
+                return res
+                  .status(400)
+                  .json({ error: "Action name not available" });
+              }
+            }
 
-        Action.schema.eachPath(path => {
-          if (req.body[path]) {
-            action[`${path}`] = req.body[path];
-          }
-        });
-
-        action
-          .save()
-          .then(() => res.status(201).send())
-          .catch(err => {
             console.error(`Error during action save():\n${err}`);
-            res.status(400).json(err);
-          });
-      })
-      .catch(err => {
-        console.error(`Error during action find():\n${err}`);
-        res.status(500).send();
-      });
+            return res.status(500).send(err);
+          }
+
+          console.error(`Error during action save():\n${err}`);
+          return res.status(500).send();
+        });
+    });
   },
 
   declineAction: (req, res) => {},
 
   search: (req, res) => {},
 
-  updateAction: (req, res) => {}
+  updateAction: (req, res) => {},
 };

--- a/src/api/controllers/ActionController.js
+++ b/src/api/controllers/ActionController.js
@@ -25,7 +25,6 @@ module.exports = {
       return res.status(400).json({ error: "Field `date` is required" });
     }
 
-    action[`dateCreated`] = new Date();
     action[`description`] = req.body.description;
 
     if (req.body.categories) {

--- a/src/api/controllers/TeamController.js
+++ b/src/api/controllers/TeamController.js
@@ -14,16 +14,15 @@ module.exports = {
       return res.status(400).json({ error: "Field `name` is required" });
     }
 
-    team[`description`] = req.body.description || null;
+    team[`description`] = req.body.description;
     team[`owner`] = req.userData.userId;
+    team[`dateCreated`] = new Date();
 
     if (req.body.categories) {
       const categories = req.body.categories;
       promises.push(
         Category.find({ name: { $in: categories } }).then((categories) => {
-          categories.forEach((category) => {
-            team[`categories`].push(category._id);
-          });
+          team[`categories`] = categories.map((c) => c._id);
         })
       );
     }
@@ -32,6 +31,7 @@ module.exports = {
       team
         .save()
         .then(() => {
+          team.__v = undefined;
           return res.status(201).send(team);
         })
         .catch((err) => {

--- a/src/api/controllers/TeamController.js
+++ b/src/api/controllers/TeamController.js
@@ -16,7 +16,6 @@ module.exports = {
 
     team[`description`] = req.body.description;
     team[`owner`] = req.userData.userId;
-    team[`dateCreated`] = new Date();
 
     if (req.body.categories) {
       const categories = req.body.categories;

--- a/src/api/controllers/TeamController.js
+++ b/src/api/controllers/TeamController.js
@@ -1,7 +1,42 @@
+const Team = require("../models/TeamModel");
+
 module.exports = {
   addMembers: (req, res) => {},
 
-  createTeam: (req, res) => {},
+  createTeam: (req, res) => {
+    const name = req.body.name;
+
+    Team.find({ name })
+      .then(team => {
+        if (team.length == 1) {
+          return res.status(409).json({
+            message: "Name not available."
+          });
+        }
+
+        team = new Team({
+          owner: req.userData.userId
+        });
+
+        Team.schema.eachPath(path => {
+          if (req.body[path]) {
+            team[`${path}`] = req.body[path];
+          }
+        });
+
+        team
+          .save()
+          .then(() => res.status(201).send())
+          .catch(err => {
+            console.error(`Error during team save():\n${err}`);
+            res.status(400).json(err);
+          });
+      })
+      .catch(err => {
+        console.error(`Error during team find():\n${err}`);
+        res.status(500).send();
+      });
+  },
 
   deleteMembers: (req, res) => {},
 

--- a/src/api/controllers/UserController.js
+++ b/src/api/controllers/UserController.js
@@ -3,22 +3,22 @@ const jwt = require("jsonwebtoken");
 
 const User = require("../models/UserModel");
 
-const generateToken = user =>
+const generateToken = (user) =>
   jwt.sign(
     // payload
     {
       userId: user._id,
-      email: user.email
+      email: user.email,
     },
     // secret
     process.env.TOKEN_SECRET_KEY,
     // options
     {
-      expiresIn: process.env.TOKEN_LIFE
+      expiresIn: process.env.TOKEN_LIFE,
     }
   );
 
-const sanitizeUser = user => {
+const sanitizeUser = (user) => {
   user = user.toJSON();
   user._id = undefined;
   user.hash = undefined;
@@ -26,23 +26,25 @@ const sanitizeUser = user => {
   return user;
 };
 
-const authResponse = user => ({
+const authResponse = (user) => ({
   jwt: generateToken(user),
-  user: sanitizeUser(user)
+  user: sanitizeUser(user),
 });
 
 module.exports = {
   changePassword: (req, res) => {},
 
+  changePhoto: (req, res) => {},
+
   getProfile: (req, res) => {
     if (req.params.user_id === req.userData.userId) {
       User.findOne({ _id: req.params.user_id })
         .exec()
-        .then(user => {
+        .then((user) => {
           user = sanitizeUser(user);
           res.status(200).json({ user });
         })
-        .catch(err => {
+        .catch((err) => {
           console.error(`Error during user find():\n${err}`);
           res.status(500).send();
         });
@@ -60,10 +62,10 @@ module.exports = {
     const password = req.body.password;
 
     User.findOne({ email })
-      .then(user => {
+      .then((user) => {
         if (!user) {
           return res.status(401).json({
-            error: "Invalid credentials"
+            error: "Invalid credentials",
           });
         }
 
@@ -77,12 +79,12 @@ module.exports = {
             res.status(200).json(authResponse(user));
           } else {
             res.status(401).json({
-              error: "Invalid credentials"
+              error: "Invalid credentials",
             });
           }
         });
       })
-      .catch(err => {
+      .catch((err) => {
         console.error(`Error during login find():\n${err}`);
         res.status(500).send();
       });
@@ -96,20 +98,20 @@ module.exports = {
     bcrypt.hash(password, 10, (err, hash) => {
       if (err) {
         return res.status(400).json({
-          error: "Invalid request"
+          error: "Invalid request",
         });
       }
 
       const user = new User({
         email,
         username,
-        hash
+        hash,
       });
 
       user
         .save()
         .then(() => res.status(201).json(authResponse(user)))
-        .catch(err => {
+        .catch((err) => {
           if (err.name === "ValidationError") {
             if (err.errors.email) {
               if (err.errors.email.kind === "regexp") {
@@ -134,5 +136,5 @@ module.exports = {
     });
   },
 
-  updateProfile: (req, res) => {}
+  updateProfile: (req, res) => {},
 };

--- a/src/api/models/ActionModel.js
+++ b/src/api/models/ActionModel.js
@@ -16,7 +16,7 @@ const ActionSchema = new mongo.Schema({
     },
   },
   date: { type: Date, required: true },
-  dateCreated: { type: Date },
+  dateCreated: { type: Date, default: Date.now },
   photo: { data: Buffer, contentType: String },
   organizer: {
     userId: { type: mongo.Schema.Types.ObjectId, ref: "User" },

--- a/src/api/models/ActionModel.js
+++ b/src/api/models/ActionModel.js
@@ -1,32 +1,28 @@
 const mongo = require("mongoose");
-const User = require("../models/UserModel");
-const Category = require("../models/CategoryModel");
+const uniqueValidator = require("mongoose-unique-validator");
 
 const ActionSchema = new mongo.Schema({
-  name: { type: String, required: true },
+  name: { type: String, required: true, unique: true },
   description: { type: String },
   categories: [{ type: mongo.Schema.Types.ObjectId, ref: "Category" }],
   location: {
     name: {
       type: String,
-      required: true
+      required: true,
     },
     coordinates: {
       type: [Number],
-      required: true
-    }
+      required: true,
+    },
   },
   date: { type: Date, required: true },
-  photo: { type: String },
+  photo: { data: Buffer, contentType: String },
   organizer: {
-    organizerId: {
-      type: mongo.Schema.Types.ObjectId,
-      required: true,
-      ref: "User"
-    },
-    isTeam: { type: Boolean, required: true }
+    userId: { type: mongo.Schema.Types.ObjectId, ref: "User" },
+    teamId: { type: mongo.Schema.Types.ObjectId, ref: "Team" },
   },
-  attendees: [{ type: mongo.Schema.Types.ObjectId, ref: "User" }]
+  attendees: [{ type: mongo.Schema.Types.ObjectId, ref: "User" }],
 });
 
+ActionSchema.plugin(uniqueValidator);
 module.exports = mongo.model("Action", ActionSchema);

--- a/src/api/models/ActionModel.js
+++ b/src/api/models/ActionModel.js
@@ -1,13 +1,14 @@
 const mongo = require("mongoose");
+const User = require("../models/UserModel");
+const Category = require("../models/CategoryModel");
 
 const ActionSchema = new mongo.Schema({
   name: { type: String, required: true },
   description: { type: String },
-  categories: { type: [mongo.Schema.Types.ObjectId] },
+  categories: [{ type: mongo.Schema.Types.ObjectId, ref: "Category" }],
   location: {
-    type: {
+    name: {
       type: String,
-      enum: ["Point"],
       required: true
     },
     coordinates: {
@@ -18,11 +19,14 @@ const ActionSchema = new mongo.Schema({
   date: { type: Date, required: true },
   photo: { type: String },
   organizer: {
-    required: true,
-    organizerId: { type: mongo.Schema.Types.ObjectId },
-    isTeam: { type: Boolean }
+    organizerId: {
+      type: mongo.Schema.Types.ObjectId,
+      required: true,
+      ref: "User"
+    },
+    isTeam: { type: Boolean, required: true }
   },
-  attendees: { type: [mongo.Schema.Types.ObjectId] }
+  attendees: [{ type: mongo.Schema.Types.ObjectId, ref: "User" }]
 });
 
 module.exports = mongo.model("Action", ActionSchema);

--- a/src/api/models/ActionModel.js
+++ b/src/api/models/ActionModel.js
@@ -16,12 +16,14 @@ const ActionSchema = new mongo.Schema({
     },
   },
   date: { type: Date, required: true },
+  dateCreated: { type: Date },
   photo: { data: Buffer, contentType: String },
   organizer: {
     userId: { type: mongo.Schema.Types.ObjectId, ref: "User" },
     teamId: { type: mongo.Schema.Types.ObjectId, ref: "Team" },
   },
   attendees: [{ type: mongo.Schema.Types.ObjectId, ref: "User" }],
+  approved: { type: Boolean, default: false },
 });
 
 ActionSchema.plugin(uniqueValidator);

--- a/src/api/models/SearchModel.js
+++ b/src/api/models/SearchModel.js
@@ -1,9 +1,10 @@
 const mongo = require("mongoose");
+const User = require("../models/UserModel");
 
 const SearchSchema = new mongo.Schema(
   {
-    user_id: { type: mongo.Schema.Types.ObjectId, required: true },
-    query: { type: String, required: true }
+    user_id: { type: mongo.Schema.Types.ObjectId, required: true, ref: "User" },
+    query: { type: String, required: true },
   },
   { _id: false }
 );

--- a/src/api/models/TeamModel.js
+++ b/src/api/models/TeamModel.js
@@ -1,14 +1,14 @@
 const mongo = require("mongoose");
-const User = require("../models/UserModel");
-const Category = require("../models/CategoryModel");
+const uniqueValidator = require("mongoose-unique-validator");
 
 const TeamSchema = new mongo.Schema({
-  name: { type: String, required: true },
+  name: { type: String, required: true, unique: true },
   description: { type: String },
-  logo: { type: String },
+  logo: { data: Buffer, contentType: String },
   owner: { type: mongo.Schema.Types.ObjectId, required: true, ref: "User" },
   members: [{ type: mongo.Schema.Types.ObjectId, ref: "User" }],
   categories: [{ type: mongo.Schema.Types.ObjectId, ref: "Category" }],
 });
 
+TeamSchema.plugin(uniqueValidator);
 module.exports = mongo.model("Team", TeamSchema);

--- a/src/api/models/TeamModel.js
+++ b/src/api/models/TeamModel.js
@@ -8,6 +8,7 @@ const TeamSchema = new mongo.Schema({
   owner: { type: mongo.Schema.Types.ObjectId, required: true, ref: "User" },
   members: [{ type: mongo.Schema.Types.ObjectId, ref: "User" }],
   categories: [{ type: mongo.Schema.Types.ObjectId, ref: "Category" }],
+  dateCreated: { type: Date },
 });
 
 TeamSchema.plugin(uniqueValidator);

--- a/src/api/models/TeamModel.js
+++ b/src/api/models/TeamModel.js
@@ -1,12 +1,14 @@
 const mongo = require("mongoose");
+const User = require("../models/UserModel");
+const Category = require("../models/CategoryModel");
 
 const TeamSchema = new mongo.Schema({
   name: { type: String, required: true },
   description: { type: String },
   logo: { type: String },
-  owner: { type: mongo.Schema.Types.ObjectId, required: true },
-  members: { type: [mongo.Schema.Types.ObjectId] },
-  categories: { type: [String] }
+  owner: { type: mongo.Schema.Types.ObjectId, required: true, ref: "User" },
+  members: [{ type: mongo.Schema.Types.ObjectId, ref: "User" }],
+  categories: [{ type: mongo.Schema.Types.ObjectId, ref: "Category" }],
 });
 
 module.exports = mongo.model("Team", TeamSchema);

--- a/src/api/models/TeamModel.js
+++ b/src/api/models/TeamModel.js
@@ -8,7 +8,7 @@ const TeamSchema = new mongo.Schema({
   owner: { type: mongo.Schema.Types.ObjectId, required: true, ref: "User" },
   members: [{ type: mongo.Schema.Types.ObjectId, ref: "User" }],
   categories: [{ type: mongo.Schema.Types.ObjectId, ref: "Category" }],
-  dateCreated: { type: Date },
+  dateCreated: { type: Date, default: Date.now },
 });
 
 TeamSchema.plugin(uniqueValidator);

--- a/src/api/models/UserModel.js
+++ b/src/api/models/UserModel.js
@@ -24,6 +24,8 @@ const UserSchema = new mongo.Schema({
   language: { type: String },
   actionsAttended: [{ type: mongo.Schema.Types.ObjectId, ref: "Action" }],
   actionsSaved: [{ type: mongo.Schema.Types.ObjectId, ref: "Action" }],
+  teamsJoined: [{ type: mongo.Schema.Types.ObjectId, ref: "Team" }],
+  teamsOwned: [{ type: mongo.Schema.Types.ObjectId, ref: "Team" }],
 });
 
 UserSchema.plugin(uniqueValidator);

--- a/src/api/models/UserModel.js
+++ b/src/api/models/UserModel.js
@@ -1,5 +1,7 @@
 const mongo = require("mongoose");
 const uniqueValidator = require("mongoose-unique-validator");
+const Category = require("../models/CategoryModel");
+const Action = require("../models/ActionModel");
 
 const UserSchema = new mongo.Schema({
   email: {
@@ -20,10 +22,10 @@ const UserSchema = new mongo.Schema({
       type: [Number]
     }
   },
-  favoriteCategories: { type: [mongo.Schema.Types.ObjectId] },
+  favoriteCategories: [{ type: mongo.Schema.Types.ObjectId, ref: "Category" }],
   language: { type: String },
-  actionsAttended: { type: [mongo.Schema.Types.ObjectId] },
-  actionsSaved: { type: [mongo.Schema.Types.ObjectId] }
+  actionsAttended: [{ type: mongo.Schema.Types.ObjectId, ref: "Action" }],
+  actionsSaved: [{ type: mongo.Schema.Types.ObjectId, ref: "Action" }]
 });
 
 UserSchema.plugin(uniqueValidator);

--- a/src/api/models/UserModel.js
+++ b/src/api/models/UserModel.js
@@ -1,31 +1,29 @@
 const mongo = require("mongoose");
 const uniqueValidator = require("mongoose-unique-validator");
-const Category = require("../models/CategoryModel");
-const Action = require("../models/ActionModel");
 
 const UserSchema = new mongo.Schema({
   email: {
     type: String,
     required: true,
     unique: true,
-    match: /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/
+    match: /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/,
   },
   username: { type: String, required: true, unique: true },
   hash: { type: String, required: true },
-  profilePhoto: { type: String },
+  profilePhoto: { data: Buffer, contentType: String },
   location: {
     type: {
       type: String,
-      enum: ["Point"]
+      enum: ["Point"],
     },
     coordinates: {
-      type: [Number]
-    }
+      type: [Number],
+    },
   },
   favoriteCategories: [{ type: mongo.Schema.Types.ObjectId, ref: "Category" }],
   language: { type: String },
   actionsAttended: [{ type: mongo.Schema.Types.ObjectId, ref: "Action" }],
-  actionsSaved: [{ type: mongo.Schema.Types.ObjectId, ref: "Action" }]
+  actionsSaved: [{ type: mongo.Schema.Types.ObjectId, ref: "Action" }],
 });
 
 UserSchema.plugin(uniqueValidator);

--- a/src/api/routes/action.js
+++ b/src/api/routes/action.js
@@ -27,6 +27,13 @@ router.delete(
   ActionController.cancelAction
 );
 
+router.put(
+  "/:action_id/photo",
+  checkAuth,
+  checkPermissions,
+  ActionController.changePhoto
+);
+
 /* Admin */
 
 router.post(

--- a/src/api/routes/team.js
+++ b/src/api/routes/team.js
@@ -15,6 +15,13 @@ router.patch("/:team_id", checkAuth, checkOwner, TeamController.updateTeam);
 
 router.delete("/:team_id", checkAuth, checkOwner, TeamController.deleteTeam);
 
+router.put(
+  "/:team_id/photo",
+  checkAuth,
+  checkOwner,
+  TeamController.changePhoto
+);
+
 /* Members */
 
 router.patch(

--- a/src/api/routes/user.js
+++ b/src/api/routes/user.js
@@ -15,4 +15,6 @@ router.get("/:user_id/profile", checkAuth, UserController.getProfile);
 
 router.patch("/me/change_password", checkAuth, UserController.changePassword);
 
+router.put("/me/photo", checkAuth, UserController.changeProfilePhoto);
+
 module.exports = router;

--- a/src/api/routes/user.js
+++ b/src/api/routes/user.js
@@ -15,6 +15,6 @@ router.get("/:user_id/profile", checkAuth, UserController.getProfile);
 
 router.patch("/me/change_password", checkAuth, UserController.changePassword);
 
-router.put("/me/photo", checkAuth, UserController.changeProfilePhoto);
+router.put("/me/photo", checkAuth, UserController.changePhoto);
 
 module.exports = router;


### PR DESCRIPTION
## About 
This PR contains the implementation of two main endpoints.
- `POST actions/create`
- `POST teams/create`

Also, we added references to models. This way we can use `populate()` when searching for a record, which lets you reference documents in other collections.

### Population example
Population is the process of automatically replacing the specified paths in the document with documents from other collections. In our case, we have, for example, the following two models: User model and Action model.
Our User model has its attendedActions field set to an array of ObjectIds. The ref option is what tells Mongoose which model to use during population, in our case the Action model. All _ids we store here must be document _ids from the Action model.

### Action creation
 The required fields to create an action are:
```
{
   "name": "Example", 
   "date":"2020-06-12T17:00:00Z",
   "location": { "name": "ABC",
		 "coordinates": [39.637939, 22.415288] },
   "organizer": { "isTeam": false }
}
```
Additional info can be added, such as description, photo and categories.
Mention that two actions can't have the same name. If so, the server will respond with HTTP code `409: Conflict`.

### Team creation
There is only one required field in order to create a team and that's the team's name. Just like actions, teams can't have the same name and the server's response will be the same. Extra information we can add is the description, the photo of the team and the categories.

I have added all the requests, both implemented and not, on a workspace at Postman. Let me know if anyone wants me to invite him.