### PR TITLE
Add pm2 configuration for production deployment

### DIFF
--- a/bin/prod.sh
+++ b/bin/prod.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+./node_modules/.bin/deploy-node-app --generate-default-env --overwrite
+docker-compose up --remove-orphans --quiet-pull -d
+./node_modules/.bin/deploy-node-app --generate-local-ports-env --format compose --overwrite

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  apps: [
+    {
+      name: "action-heores",
+      script: "./src/api/index.js",
+      instances: 1,
+      autorestart: true,
+      watch: false,
+      max_memory_restart: "1G",
+      env: {
+        NODE_ENV: "development",
+      },
+      env_production: {
+        NODE_ENV: "production",
+      },
+    },
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2980,6 +2980,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
@@ -6400,6 +6409,12 @@
         "schema-utils": "^2.5.0"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.0.1.tgz",
@@ -8735,6 +8750,7 @@
           "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
@@ -11551,6 +11567,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
@@ -17655,6 +17672,7 @@
           "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
@@ -18422,6 +18440,7 @@
           "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -31,7 +31,7 @@ mongo
   .connect(dbUri, {
     useNewUrlParser: true,
     useUnifiedTopology: true,
-    useCreateIndex: true
+    useCreateIndex: true,
   })
   .then(() => console.log("Connected to database."))
   .catch(() => console.error("Could not connect to database!"));
@@ -47,13 +47,13 @@ morgan.token("ip", (req, res) => {
 
 var accessLogStream = rfs.createStream("access.log", {
   interval: "30d", // rotate monthly
-  path: path.join(process.cwd(), "log")
+  path: path.join(process.cwd(), "log"),
 });
 
 // Logging to file
 app.use(
   morgan("[:date[web]] :ip :method :url :status :body", {
-    stream: accessLogStream
+    stream: accessLogStream,
   })
 );
 
@@ -74,7 +74,7 @@ app.use("/contact", contactRoutes);
 if (process.env.NODE_ENV == "production") {
   // Serve static content in build directory
   app.use(express.static(path.join(process.cwd(), "build")));
-  app.get("/", function(req, res) {
+  app.get("/*", function(req, res) {
     res.sendFile(path.join(process.cwd(), "build", "index.html"));
   });
 } else {
@@ -90,7 +90,7 @@ app.use((error, req, res, next) => {
   res.status(error.status || 500);
   if (error.status) {
     res.json({
-      error: error.message
+      error: error.message,
     });
   } else {
     res.send();


### PR DESCRIPTION
This PR adds the configuration required for the project to be able to be deployed to the production server using [PM2](https://pm2.keymetrics.io/).

The server's files are first uploaded to the server using a git repository, as explained [in this Medium article](https://medium.com/@aunnnn/automate-digitalocean-deployment-for-node-js-with-git-and-pm2-67a3cfa7a02b). Perhaps this could be done automatically in the future with a GitHub Action (?).

After that, the following post-receive hook gets executed on the server:
```sh
echo "post-receive: triggered"
cd /opt/live/action-heroes

echo "post-receive: checking out"
git --git-dir=/opt/action-heroes.git --work-tree=/opt/live/action-heroes checkout master -f

echo "post-receive: installing dependencies"
npm install \
&& echo "post-receive: creating production build" \
&& npm run build \
&& echo "post-receive: starting docker containers" \
&& sh bin/prod.sh \
&& echo "post-receive: restarting pm2" \
&& pm2 restart ecosystem.config.js --env production \

echo "post-receive: completed!"
```
At this point, the app is deployed and can be accessed on https://snf-12972.ok-kno.grnetcloud.net/ :smile:

I also included a fix for content server, which closes #22. More info can be found inside the issue.