### PR TITLE
FilterList responsiveness for devices <800px

### DIFF
--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -3,7 +3,8 @@
   "filterlist": {
     "filters": "Φίλτρα",
     "clear": "Εκκαθάριση",
-    "categories": "Κατηγορίες"
+    "categories": "Κατηγορίες",
+    "none": "Κανένα."
   },
   "nav": {
     "actions": "Δράσεις",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3,7 +3,8 @@
   "filterlist": {
     "filters": "Filters",
     "clear": "Clear",
-    "categories": "Categories"
+    "categories": "Categories",
+    "none": "None."
   },
   "nav": {
     "actions": "Actions",

--- a/src/www/components/filterlist/FilterList.jsx
+++ b/src/www/components/filterlist/FilterList.jsx
@@ -6,6 +6,19 @@ import { useTranslation } from "react-i18next";
 const isChecked = (item, list) =>
   Object.keys(list).find((k) => list[k] === item);
 
+const listFilters = (t, selected, onRemove) => {
+  if (selected.length === 0) {
+    return <p children={t("filterlist.none")} />;
+  }
+
+  return selected.map((c) => (
+    <li key={c}>
+      <p children={c} />
+      <p onClick={() => onRemove(c)} children="x" />
+    </li>
+  ));
+};
+
 export default ({ categories, selected, onCheckbox, onClear, onRemove }) => {
   const { t } = useTranslation();
   return (
@@ -15,32 +28,27 @@ export default ({ categories, selected, onCheckbox, onClear, onRemove }) => {
           <h2>{t("filterlist.filters")}</h2>
           <p onClick={onClear}>{t("filterlist.clear")}</p>
         </span>
-        <ul>
-          {selected.map((c) => (
-            <li key={c}>
-              <p children={c} />
-              <p onClick={() => onRemove(c)} children="x" />
-            </li>
-          ))}
-        </ul>
+        <ul children={listFilters(t, selected, onRemove)} />
       </div>
       <div className="FilterList_menu">
         <h4>{t("filterlist.categories")}</h4>
-        {Object.keys(categories).map((c) => {
-          const category = categories[c];
-          const name = category.name;
-          return (
-            <label key={c}>
-              {name}
-              <input
-                type="checkbox"
-                checked={isChecked(name, selected)}
-                onChange={(event) => onCheckbox(event, name)}
-              />
-              <span className="checkmark"></span>
-            </label>
-          );
-        })}
+        <div>
+          {Object.keys(categories).map((c) => {
+            const category = categories[c];
+            const name = category.name;
+            return (
+              <label key={c}>
+                {name}
+                <input
+                  type="checkbox"
+                  checked={isChecked(name, selected)}
+                  onChange={(event) => onCheckbox(event, name)}
+                />
+                <span className="checkmark"></span>
+              </label>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/www/components/filterlist/FilterList.scss
+++ b/src/www/components/filterlist/FilterList.scss
@@ -151,8 +151,10 @@
 @media only screen and(max-width: 800px) {
   .FilterList {
     align-self: center;
+    border-right: none;
     flex-direction: column-reverse;
     max-width: unset;
+    padding-right: 0;
 
     &_display > span > h2 {
       font-size: 1.5rem;

--- a/src/www/components/filterlist/FilterList.scss
+++ b/src/www/components/filterlist/FilterList.scss
@@ -2,10 +2,13 @@
 
 .FilterList {
   align-items: flex-start;
+  border-right: 1px solid rgba($color: black, $alpha: 0.5);
   display: flex;
   flex-direction: column;
+  margin-top: 2rem;
   max-width: 15rem;
   min-width: 12.5rem;
+  padding-right: 2rem;
 
   &_display {
     width: 100%;
@@ -40,15 +43,21 @@
       flex-wrap: wrap;
       list-style: none;
       margin: 0;
+      min-height: 5rem;
       padding-left: 0;
 
+      > p {
+        margin: 0.75rem;
+      }
+
       > li {
-        background-color: white;
-        border: 1px solid royalblue;
+        background-color: rgba($color: white, $alpha: 0.6);
+        border: 1px solid rgba($color: royalblue, $alpha: 0.6);
         border-radius: 0.5rem;
         display: flex;
         flex-direction: row;
         justify-content: space-between;
+        height: fit-content;
         margin-top: 0.5rem;
         min-width: 2rem;
         padding: 0.25rem 0.5rem;
@@ -76,7 +85,7 @@
       font-size: 1.25rem;
     }
 
-    > label {
+    label {
       display: block;
       position: relative;
       padding-left: 30px;
@@ -134,6 +143,38 @@
         border: solid white;
         border-width: 0 3px 3px 0;
         transform: rotate(45deg);
+      }
+    }
+  }
+}
+
+@media only screen and(max-width: 800px) {
+  .FilterList {
+    align-self: center;
+    flex-direction: column-reverse;
+    max-width: unset;
+
+    &_display > span > h2 {
+      font-size: 1.5rem;
+    }
+
+    &_menu {
+      margin-bottom: 2rem;
+
+      > h4 {
+        font-size: 1.5rem;
+        margin-top: 0;
+      }
+
+      > div {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        margin-left: -0.5rem;
+
+        > label {
+          margin-left: 0.5rem;
+        }
       }
     }
   }


### PR DESCRIPTION
This PR adds responsiveness to the **FilterList** component since the previous design was too cluttered for devices with a screen width of < 800px.

#### Desktop View:
![desktop](https://user-images.githubusercontent.com/8458550/79894799-a91ed480-840e-11ea-8170-78b950e35e53.png)

#### Mobile View:
![mobile](https://user-images.githubusercontent.com/8458550/79894800-aa500180-840e-11ea-869f-3c8f1d8f7cf8.png)

Keep in mind that you'll have to manually change the flex-direction of your page to accommodate for this wider filter list on smaller screen sizes!