### PR TITLE
Saved team id to user after team creation

### DIFF
--- a/src/api/controllers/TeamController.js
+++ b/src/api/controllers/TeamController.js
@@ -1,5 +1,6 @@
 const Team = require("../models/TeamModel");
 const Category = require("../models/CategoryModel");
+const User = require("../models/UserModel");
 
 module.exports = {
   addMembers: (req, res) => {},
@@ -31,7 +32,17 @@ module.exports = {
         .save()
         .then(() => {
           team.__v = undefined;
-          return res.status(201).send(team);
+          User.findByIdAndUpdate(
+            { _id: req.userData.userId },
+            { $addToSet: { teamsOwned: team._id } }
+          )
+            .then(() => {
+              return res.status(201).send(team);
+            })
+            .catch((err) => {
+              console.error(`Error during user update():\n${err}`);
+              return res.status(500).send();
+            });
         })
         .catch((err) => {
           if (err.name == "ValidationError") {


### PR DESCRIPTION
After the creation of a team, the team's id should have been stored to user's owned teams. This wasn't implemented in the previous PR, but now is :smile: 