### PR TITLE
API: Implementation of change password

### DIFF
--- a/src/api/controllers/UserController.js
+++ b/src/api/controllers/UserController.js
@@ -51,15 +51,10 @@ module.exports = {
     User.findById({ _id: req.userData.userId })
       .exec()
       .then((user) => {
-        if (!user) {
-          return res.status(401).json({
-            error: "Invalid credentials",
-          });
-        }
-
         bcrypt.compare(previousPassword, user.hash, (err, success) => {
           if (err) {
-            return res.status(500).send(err);
+            console.error(`Error during password comparison:\n${err}`);
+            return res.status(500).send();
           }
 
           if (success) {

--- a/src/api/controllers/UserController.js
+++ b/src/api/controllers/UserController.js
@@ -32,7 +32,60 @@ const authResponse = (user) => ({
 });
 
 module.exports = {
-  changePassword: (req, res) => {},
+  changePassword: (req, res) => {
+    const previousPassword = req.body.previousPassword;
+    const newPassword = req.body.newPassword;
+
+    if (!req.body.previousPassword) {
+      return res.status(400).json({
+        error: "Field `previousPassword` is required",
+      });
+    }
+
+    if (!req.body.newPassword) {
+      return res.status(400).json({
+        error: "Field `newPassword` is required",
+      });
+    }
+
+    User.findById({ _id: req.userData.userId })
+      .exec()
+      .then((user) => {
+        if (!user) {
+          return res.status(401).json({
+            error: "Invalid credentials",
+          });
+        }
+
+        bcrypt.compare(previousPassword, user.hash, (err, success) => {
+          if (err) {
+            return res.status(500).send(err);
+          }
+
+          if (success) {
+            bcrypt.hash(newPassword, 10, (err, hash) => {
+              if (err) {
+                console.error(`Error during hashing:\n${err}`);
+                return res.status(500).send();
+              } else {
+                user.hash = hash;
+                user.save().then(() => {
+                  return res.json(authResponse(user));
+                });
+              }
+            });
+          } else {
+            return res.status(401).json({
+              error: "Invalid password",
+            });
+          }
+        });
+      })
+      .catch((err) => {
+        console.error(`Error during user find():\n${err}`);
+        return res.status(500).json();
+      });
+  },
 
   changePhoto: (req, res) => {},
 


### PR DESCRIPTION
### About
This PR contains the implementation of the change of password (server's side). The previous password and the new password must be given to the server as shown in the example above. Both fields are required to continue the procedure.

![image](https://user-images.githubusercontent.com/37141166/82310970-c030f200-99cd-11ea-89e2-22d5de85bd39.png)

Given the previous password, the server will check whether the hash of this password matches the one stored in the database and if the comparison is successful the new password will be hashed and stored. If the comparison is unsuccessful the previousPassword isn't the right one and the appropriate response and message will be sent.

