### PR TITLE
API: Update action

### DIFF
--- a/src/api/CustomError.js
+++ b/src/api/CustomError.js
@@ -1,0 +1,9 @@
+class CustomError extends Error {
+  constructor(message, code) {
+    super(message);
+    this.name = "CustomError";
+    this.code = code;
+  }
+}
+
+module.exports = CustomError;

--- a/src/api/controllers/ActionController.js
+++ b/src/api/controllers/ActionController.js
@@ -34,18 +34,16 @@ module.exports = {
       );
     }
 
-    if (req.body.team) {
+    if (req.body.organizer) {
       promises.push(
-        Team.findOne({ name: req.body.team }).then((team) => {
+        Team.findOne({ name: req.body.organizer }).then((team) => {
           if (team) {
-            action[`organizer`][`teamId`] = team._id;
+            action[`organizer`] = team._id;
           } else {
             return res.status(400).json({ error: "Invalid organizer" });
           }
         })
       );
-    } else {
-      action[`organizer`][`userId`] = req.userData.userId;
     }
 
     if (req.body.location) {

--- a/src/api/controllers/ActionController.js
+++ b/src/api/controllers/ActionController.js
@@ -170,10 +170,11 @@ module.exports = {
         Action.findOneAndUpdate(
           { _id: req.params.action_id },
           { $set: query },
-          { runValidators: true, context: "query" }
+          { runValidators: true, context: "query", new: true }
         )
-          .then(() => {
-            return res.status(200).send();
+          .then((action) => {
+            action.__v = undefined;
+            return res.status(200).send(action);
           })
           .catch((err) => {
             if (err.name == "ValidationError") {

--- a/src/api/controllers/ActionController.js
+++ b/src/api/controllers/ActionController.js
@@ -44,6 +44,8 @@ module.exports = {
           }
         })
       );
+    } else {
+      return res.status(400).json({ error: "Field `organizer` is required" });
     }
 
     if (req.body.location) {
@@ -124,10 +126,9 @@ module.exports = {
     }
 
     if (req.body.categories) {
-      const categories = req.body.categories;
       promises.push(
-        Category.find({ name: { $in: categories } }).then((categories) => {
-          query[`categories`] = categories.map((c) => c._id);
+        Category.find({ name: { $in: req.body.categories } }).then((cat) => {
+          query[`categories`] = cat.map((c) => c._id);
         })
       );
     }

--- a/src/api/controllers/ActionController.js
+++ b/src/api/controllers/ActionController.js
@@ -38,7 +38,13 @@ module.exports = {
       promises.push(
         Team.findOne({ _id: req.body.organizer }).then((team) => {
           if (team) {
-            action[`organizer`] = team._id;
+            if (team.owner == req.userData.userId) {
+              action[`organizer`] = team._id;
+            } else {
+              return res
+                .status(409)
+                .json({ error: "Insufficient permissions" });
+            }
           } else {
             return res.status(400).json({ error: "Invalid organizer" });
           }
@@ -97,6 +103,8 @@ module.exports = {
               }
             }
 
+            /* BUG: When the user isn't the owner of the team the right message is sent as a 
+            response but the code reaches this point and prints "Path `organizer` is required" error. */
             console.error(`Error during action save():\n${err}`);
             return res.status(500).send();
           }

--- a/src/api/controllers/ActionController.js
+++ b/src/api/controllers/ActionController.js
@@ -36,7 +36,7 @@ module.exports = {
 
     if (req.body.organizer) {
       promises.push(
-        Team.findOne({ name: req.body.organizer }).then((team) => {
+        Team.findOne({ _id: req.body.organizer }).then((team) => {
           if (team) {
             action[`organizer`] = team._id;
           } else {

--- a/src/api/controllers/ActionController.js
+++ b/src/api/controllers/ActionController.js
@@ -3,8 +3,6 @@ const Team = require("../models/TeamModel");
 const Category = require("../models/CategoryModel");
 
 module.exports = {
-  approveAction: (req, res) => {},
-
   cancelAction: (req, res) => {},
 
   changePhoto: (req, res) => {},
@@ -108,8 +106,6 @@ module.exports = {
         });
     });
   },
-
-  declineAction: (req, res) => {},
 
   search: (req, res) => {},
 

--- a/src/api/controllers/ActionController.js
+++ b/src/api/controllers/ActionController.js
@@ -42,7 +42,7 @@ module.exports = {
               action[`organizer`] = team._id;
             } else {
               return res
-                .status(409)
+                .status(403)
                 .json({ error: "Insufficient permissions" });
             }
           } else {

--- a/src/api/middleware/check-admin.js
+++ b/src/api/middleware/check-admin.js
@@ -1,3 +1,0 @@
-module.exports = (req, res, next) => {
-  next();
-};

--- a/src/api/middleware/check-permissions.js
+++ b/src/api/middleware/check-permissions.js
@@ -1,3 +1,0 @@
-module.exports = (req, res, next) => {
-  next();
-};

--- a/src/api/middleware/extract-team.js
+++ b/src/api/middleware/extract-team.js
@@ -1,0 +1,21 @@
+const Action = require("../models/ActionModel");
+
+module.exports = (req, res, next) => {
+  Action.findOne({ _id: req.params.action_id })
+    .then((action) => {
+      if (!action) {
+        return res.status(400).json({ error: "Invalid action id" });
+      } else {
+        req.params.team_id = action.organizer;
+        next();
+      }
+    })
+    .catch((err) => {
+      if (err.name == "CastError") {
+        return res.status(400).json({ error: "Invalid action id" });
+      } else {
+        console.error(`Error during action find():\n${err}`);
+        return res.status(500).send();
+      }
+    });
+};

--- a/src/api/models/ActionModel.js
+++ b/src/api/models/ActionModel.js
@@ -18,7 +18,7 @@ const ActionSchema = new mongo.Schema({
   date: { type: Date, required: true },
   dateCreated: { type: Date, default: Date.now },
   photo: { data: Buffer, contentType: String },
-  organizer: { type: mongo.Schema.Types.ObjectId, ref: "Team" },
+  organizer: { type: mongo.Schema.Types.ObjectId, ref: "Team", required: true },
   attendees: [{ type: mongo.Schema.Types.ObjectId, ref: "User" }],
 });
 

--- a/src/api/models/ActionModel.js
+++ b/src/api/models/ActionModel.js
@@ -18,10 +18,7 @@ const ActionSchema = new mongo.Schema({
   date: { type: Date, required: true },
   dateCreated: { type: Date, default: Date.now },
   photo: { data: Buffer, contentType: String },
-  organizer: {
-    userId: { type: mongo.Schema.Types.ObjectId, ref: "User" },
-    teamId: { type: mongo.Schema.Types.ObjectId, ref: "Team" },
-  },
+  organizer: { type: mongo.Schema.Types.ObjectId, ref: "Team" },
   attendees: [{ type: mongo.Schema.Types.ObjectId, ref: "User" }],
   approved: { type: Boolean, default: false },
 });

--- a/src/api/models/ActionModel.js
+++ b/src/api/models/ActionModel.js
@@ -20,7 +20,6 @@ const ActionSchema = new mongo.Schema({
   photo: { data: Buffer, contentType: String },
   organizer: { type: mongo.Schema.Types.ObjectId, ref: "Team" },
   attendees: [{ type: mongo.Schema.Types.ObjectId, ref: "User" }],
-  approved: { type: Boolean, default: false },
 });
 
 ActionSchema.plugin(uniqueValidator);

--- a/src/api/models/ActionModel.js
+++ b/src/api/models/ActionModel.js
@@ -2,7 +2,12 @@ const mongo = require("mongoose");
 const uniqueValidator = require("mongoose-unique-validator");
 
 const ActionSchema = new mongo.Schema({
-  name: { type: String, required: true, unique: true },
+  name: {
+    type: String,
+    required: true,
+    unique: true,
+    uniqueCaseInsensitive: true,
+  },
   description: { type: String },
   categories: [{ type: mongo.Schema.Types.ObjectId, ref: "Category" }],
   location: {

--- a/src/api/routes/action.js
+++ b/src/api/routes/action.js
@@ -3,6 +3,7 @@ const router = express.Router();
 
 const checkAuth = require("../middleware/check-auth");
 const checkOwner = require("../middleware/check-owner");
+const extractTeam = require("../middleware/extract-team");
 const logSearch = require("../middleware/log-search");
 
 const ActionController = require("../controllers/ActionController");
@@ -15,6 +16,7 @@ router.post("/create", checkAuth, ActionController.createAction);
 router.patch(
   "/:action_id",
   checkAuth,
+  extractTeam,
   checkOwner,
   ActionController.updateAction
 );
@@ -22,6 +24,7 @@ router.patch(
 router.delete(
   "/:action_id",
   checkAuth,
+  extractTeam,
   checkOwner,
   ActionController.cancelAction
 );
@@ -29,6 +32,7 @@ router.delete(
 router.put(
   "/:action_id/photo",
   checkAuth,
+  extractTeam,
   checkOwner,
   ActionController.changePhoto
 );

--- a/src/api/routes/action.js
+++ b/src/api/routes/action.js
@@ -34,22 +34,6 @@ router.put(
   ActionController.changePhoto
 );
 
-/* Admin */
-
-router.post(
-  "/:action_id/approve",
-  checkAuth,
-  checkAdmin,
-  ActionController.approveAction
-);
-
-router.post(
-  "/:action_id/decline",
-  checkAuth,
-  checkAdmin,
-  ActionController.declineAction
-);
-
 /* Attendants */
 
 router.post("/:action_id/attend", checkAuth, ActionUserController.addAttendant);

--- a/src/api/routes/action.js
+++ b/src/api/routes/action.js
@@ -2,7 +2,7 @@ const express = require("express");
 const router = express.Router();
 
 const checkAuth = require("../middleware/check-auth");
-const checkPermissions = require("../middleware/check-permissions");
+const checkOwner = require("../middleware/check-owner");
 const logSearch = require("../middleware/log-search");
 
 const ActionController = require("../controllers/ActionController");
@@ -15,21 +15,21 @@ router.post("/create", checkAuth, ActionController.createAction);
 router.patch(
   "/:action_id",
   checkAuth,
-  checkPermissions,
+  checkOwner,
   ActionController.updateAction
 );
 
 router.delete(
   "/:action_id",
   checkAuth,
-  checkPermissions,
+  checkOwner,
   ActionController.cancelAction
 );
 
 router.put(
   "/:action_id/photo",
   checkAuth,
-  checkPermissions,
+  checkOwner,
   ActionController.changePhoto
 );
 

--- a/src/api/routes/action.js
+++ b/src/api/routes/action.js
@@ -2,7 +2,6 @@ const express = require("express");
 const router = express.Router();
 
 const checkAuth = require("../middleware/check-auth");
-const checkAdmin = require("../middleware/check-admin");
 const checkPermissions = require("../middleware/check-permissions");
 const logSearch = require("../middleware/log-search");
 


### PR DESCRIPTION
## About
In this PR, two main things changed. Update action is now implemented and the organizer of an action can only be a team.

### Update action
`Update action` endpoint is now implemented. The owner can change the name of the action (upon availability), the description, the date of the action, the location, and the categories. A request including all the above will look something like that:

![image](https://user-images.githubusercontent.com/37141166/83734247-67ad5600-a657-11ea-80e3-d668832fd3f3.png)

### Action's organizer
Since we decided to only let teams organize events, we deleted the `admin` functionality, including endpoints to approve or decline an action, and changed the action model to accept only teams as an organizer. Also, we simplified the organizer on the `create action` endpoint.