### PR TITLE
API: Update team

### DIFF
--- a/src/api/controllers/TeamController.js
+++ b/src/api/controllers/TeamController.js
@@ -93,10 +93,11 @@ module.exports = {
         Team.findOneAndUpdate(
           { _id: req.params.team_id },
           { $set: query },
-          { runValidators: true, context: "query" }
+          { runValidators: true, context: "query", new: true }
         )
-          .then(() => {
-            return res.status(200).send();
+          .then((team) => {
+            team.__v = undefined;
+            return res.status(200).send(team);
           })
           .catch((err) => {
             if (err.name == "ValidationError") {

--- a/src/api/controllers/TeamController.js
+++ b/src/api/controllers/TeamController.js
@@ -68,5 +68,52 @@ module.exports = {
 
   search: (req, res) => {},
 
-  updateTeam: (req, res) => {},
+  updateTeam: (req, res) => {
+    var query = {};
+    var promises = [];
+
+    if (req.body.name) {
+      query[`name`] = req.body.name;
+    }
+
+    if (req.body.description) {
+      query[`description`] = req.body.description;
+    }
+
+    if (req.body.categories) {
+      promises.push(
+        Category.find({ name: { $in: req.body.categories } }).then((cat) => {
+          query[`categories`] = cat.map((c) => c._id);
+        })
+      );
+    }
+
+    Promise.all(promises)
+      .then(() => {
+        Team.findOneAndUpdate(
+          { _id: req.params.team_id },
+          { $set: query },
+          { runValidators: true, context: "query" }
+        )
+          .then(() => {
+            return res.status(200).send();
+          })
+          .catch((err) => {
+            if (err.name == "ValidationError") {
+              if (err.errors.name.kind == "unique") {
+                return res
+                  .status(400)
+                  .json({ error: "Team name not available" });
+              }
+            } else {
+              console.error(`Error during Team update:\n${err}`);
+              return res.status(500).send();
+            }
+          });
+      })
+      .catch((err) => {
+        console.error(`Error during Promise.all():\n${err}`);
+        return res.status(500).send();
+      });
+  },
 };

--- a/src/api/middleware/check-owner.js
+++ b/src/api/middleware/check-owner.js
@@ -3,7 +3,9 @@ const Team = require("../models/TeamModel");
 module.exports = (req, res, next) => {
   Team.findOne({ _id: req.params.team_id })
     .then((team) => {
-      if (team.owner == req.userData.userId) {
+      if (!team) {
+        return res.status(400).json({ error: "Invalid team id" });
+      } else if (team.owner == req.userData.userId) {
         next();
       } else {
         return res.status(403).json({
@@ -12,7 +14,11 @@ module.exports = (req, res, next) => {
       }
     })
     .catch((err) => {
-      console.error(`Error during team find():\n${err}`);
-      res.status(500).send();
+      if (err.name == "CastError") {
+        return res.status(400).json({ error: "Invalid team id" });
+      } else {
+        console.error(`Error during team find():\n${err}`);
+        return res.status(500).send();
+      }
     });
 };

--- a/src/api/middleware/check-owner.js
+++ b/src/api/middleware/check-owner.js
@@ -1,3 +1,18 @@
+const Team = require("../models/TeamModel");
+
 module.exports = (req, res, next) => {
-  next();
+  Team.findOne({ _id: req.params.team_id })
+    .then((team) => {
+      if (team.owner == req.userData.userId) {
+        next();
+      } else {
+        return res.status(409).json({
+          error: "Insufficient permissions",
+        });
+      }
+    })
+    .catch((err) => {
+      console.error(`Error during team find():\n${err}`);
+      res.status(500).send();
+    });
 };

--- a/src/api/middleware/check-owner.js
+++ b/src/api/middleware/check-owner.js
@@ -6,7 +6,7 @@ module.exports = (req, res, next) => {
       if (team.owner == req.userData.userId) {
         next();
       } else {
-        return res.status(409).json({
+        return res.status(403).json({
           error: "Insufficient permissions",
         });
       }

--- a/src/api/models/TeamModel.js
+++ b/src/api/models/TeamModel.js
@@ -2,7 +2,12 @@ const mongo = require("mongoose");
 const uniqueValidator = require("mongoose-unique-validator");
 
 const TeamSchema = new mongo.Schema({
-  name: { type: String, required: true, unique: true },
+  name: {
+    type: String,
+    required: true,
+    unique: true,
+    uniqueCaseInsensitive: true,
+  },
   description: { type: String },
   photo: { data: Buffer, contentType: String },
   owner: { type: mongo.Schema.Types.ObjectId, required: true, ref: "User" },


### PR DESCRIPTION
### About
This PR contains the implementation of the `update team endpoint` and the `check-owner middleware`. 

### Update team
There are only 3 things the owner can change here (name of the team, description, and categories). Photo and members have their own endpoints. A request including all the above will look something like that:

![image](https://user-images.githubusercontent.com/37141166/83964538-76457880-a8b6-11ea-9a79-d8b59a6dd4b7.png)

### Check owner
Only the owner of the team can access this endpoint. If someone else tries to access it the server returns `409 http error code:` and the message `Insufficient permissions`.