### PR TITLE
Fix duplicate declaration for imports & dump/restore scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "prod": "NODE_ENV=production node src/api/index.js",
     "populate-categories": "node scripts/populate-categories.js",
     "eject-www": "react-scripts eject",
+    "restore-db": "export $(cat .env | xargs) && mongorestore --gzip --archive=db.mongodump --uri=\"mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@${MONGO_SERVICE_HOST}:${MONGO_SERVICE_PORT}/${MONGO_INITDB_DATABASE}?authSource=admin\"",
+    "dump-db": "export $(cat .env | xargs) && mongodump --gzip --archive=db.mongodump --uri=\"mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@${MONGO_SERVICE_HOST}:${MONGO_SERVICE_PORT}/${MONGO_INITDB_DATABASE}?authSource=admin\"",
     "mongo": "export $(cat .env | xargs) && mongo mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@${MONGO_SERVICE_HOST}:${MONGO_SERVICE_PORT}/${MONGO_INITDB_DATABASE}?authSource=admin"
   },
   "eslintConfig": {

--- a/src/api/controllers/UserController.js
+++ b/src/api/controllers/UserController.js
@@ -8,8 +8,6 @@ const Category = require("../models/CategoryModel");
 const Image = require("../models/ImageModel");
 const Team = require("../models/TeamModel");
 const User = require("../models/UserModel");
-const Action = require("../models/ActionModel");
-const Team = require("../models/TeamModel");
 
 const generateToken = (user) =>
   jwt.sign(


### PR DESCRIPTION
## About
This PR fixes an error that was introduced with #64, which incorrectly imports certain mongoose models twice.
Additionally, I included some mongodump/mongorestore scripts that will allow us to back-up and restore the database.