### PR TITLE
Deleted search endpoints and middleware

### DIFF
--- a/src/api/controllers/ActionController.js
+++ b/src/api/controllers/ActionController.js
@@ -275,8 +275,6 @@ module.exports = {
     updateSaves(req, res, false);
   },
 
-  search: (req, res) => {},
-
   updateAction: (req, res) => {
     var query = {};
     var promises = [];

--- a/src/api/controllers/TeamController.js
+++ b/src/api/controllers/TeamController.js
@@ -223,8 +223,6 @@ module.exports = {
     updateFollowers(req, res, false);
   },
 
-  search: (req, res) => {},
-
   updateTeam: (req, res) => {
     var query = {};
     var promises = [];

--- a/src/api/middleware/log-search.js
+++ b/src/api/middleware/log-search.js
@@ -1,3 +1,0 @@
-module.exports = (req, res, next) => {
-  next();
-};

--- a/src/api/routes/action.js
+++ b/src/api/routes/action.js
@@ -5,7 +5,6 @@ const checkAuth = require("../middleware/check-auth");
 const checkAuthOptional = require("../middleware/check-auth-optional");
 const checkOwner = require("../middleware/check-owner");
 const extractTeam = require("../middleware/extract-team");
-const logSearch = require("../middleware/log-search");
 const upload = require("../middleware/upload")(720, 405); // resize images to 720x405
 
 const ActionController = require("../controllers/ActionController");
@@ -47,9 +46,7 @@ router.post("/:action_id/save", checkAuth, ActionController.addSave);
 
 router.delete("/:action_id/save", checkAuth, ActionController.removeSave);
 
-/* Search */
-
-router.get("/search", checkAuth, logSearch, ActionController.search);
+/* GET */
 
 router.get("/", ActionController.getAll);
 

--- a/src/api/routes/team.js
+++ b/src/api/routes/team.js
@@ -5,7 +5,6 @@ const checkAuth = require("../middleware/check-auth");
 const checkAuthOptional = require("../middleware/check-auth-optional");
 const checkOwner = require("../middleware/check-owner");
 const upload = require("../middleware/upload")(128, 128); // resize files to 128x128
-const logSearch = require("../middleware/log-search");
 
 const TeamController = require("../controllers/TeamController");
 
@@ -29,9 +28,7 @@ router.post("/:team_id/follow", checkAuth, TeamController.addFollower);
 
 router.delete("/:team_id/follow", checkAuth, TeamController.removeFollower);
 
-/* Search */
-
-router.get("/search", checkAuth, logSearch, TeamController.search);
+/* GET */
 
 router.get("/", TeamController.getAll);
 


### PR DESCRIPTION
### About
In this PR we deleted all the endpoints and the middleware regarding the search of a team/action from the user because the search isn't performed by the backend as we initially planned. Thus, the corresponding endpoints are useless.