### PR TITLE
Standard page height, fix ActionPopup reset, empty category placeholder

### DIFF
--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -129,7 +129,8 @@
     }
   },
   "actioncard": {
-    "categories": "Κατηγορίες"
+    "categories": "Κατηγορίες",
+    "none": "Καμία!"
   },
   "categories": {
     "animals": "Ζώα",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -129,7 +129,8 @@
     }
   },
   "actioncard": {
-    "categories": "Categories"
+    "categories": "Categories",
+    "none": "None!"
   },
   "categories": {
     "animals": "Animals",

--- a/src/api/routes/action.js
+++ b/src/api/routes/action.js
@@ -5,7 +5,7 @@ const checkAuth = require("../middleware/check-auth");
 const checkAuthOptional = require("../middleware/check-auth-optional");
 const checkOwner = require("../middleware/check-owner");
 const extractTeam = require("../middleware/extract-team");
-const upload = require("../middleware/upload")(720, 405); // resize images to 720x405
+const upload = require("../middleware/upload")(1920, 1080); // resize images to 1920x1080
 
 const ActionController = require("../controllers/ActionController");
 

--- a/src/www/App.scss
+++ b/src/www/App.scss
@@ -1,12 +1,10 @@
 .App {
   text-align: center;
-  overflow: hidden;
 
   main {
     > div {
       padding-top: 4rem;
-      overflow: auto;
-      height: calc(100vh - 8.25rem); // nav: 4rem, footer: 4.25rem
+      min-height: calc(100vh - 8.25rem); // nav: 4rem, footer: 4.25rem
     }
   }
 
@@ -25,11 +23,5 @@
     overflow: hidden;
     text-overflow: ellipsis;
     word-break: break-all;
-  }
-
-  @media only screen and(max-width: 550px) {
-    main > div {
-      height: calc(100vh - 10.25rem); // nav: 4rem, footer: 6.25rem
-    }
   }
 }

--- a/src/www/App.scss
+++ b/src/www/App.scss
@@ -1,8 +1,13 @@
 .App {
   text-align: center;
+  overflow: hidden;
 
   main {
-    margin-top: 4rem;
+    > div {
+      padding-top: 4rem;
+      overflow: auto;
+      height: calc(100vh - 8.25rem); // nav: 4rem, footer: 4.25rem
+    }
   }
 
   .ScrollButton {
@@ -20,5 +25,11 @@
     overflow: hidden;
     text-overflow: ellipsis;
     word-break: break-all;
+  }
+
+  @media only screen and(max-width: 550px) {
+    main > div {
+      height: calc(100vh - 10.25rem); // nav: 4rem, footer: 6.25rem
+    }
   }
 }

--- a/src/www/components/actioncard/ActionCard.jsx
+++ b/src/www/components/actioncard/ActionCard.jsx
@@ -31,6 +31,7 @@ export default ({ action }) => {
           </div>
           <div className="ActionCard_categories">
             <h1>{t("actioncard.categories")}:</h1>
+            {categories.length == 0 && <p children={t("actioncard.none")} />}
             <ul>
               {categories.map((name) => (
                 <li key={name}>{t(`categories.${name.toLowerCase()}`)}</li>

--- a/src/www/components/actioncard/ActionCard.jsx
+++ b/src/www/components/actioncard/ActionCard.jsx
@@ -31,7 +31,7 @@ export default ({ action }) => {
           </div>
           <div className="ActionCard_categories">
             <h1>{t("actioncard.categories")}:</h1>
-            {categories.length == 0 && <p children={t("actioncard.none")} />}
+            {categories.length === 0 && <p children={t("actioncard.none")} />}
             <ul>
               {categories.map((name) => (
                 <li key={name}>{t(`categories.${name.toLowerCase()}`)}</li>

--- a/src/www/components/footer/Footer.scss
+++ b/src/www/components/footer/Footer.scss
@@ -1,7 +1,5 @@
 footer {
   background-color: whitesmoke;
-  bottom: 0;
-  position: fixed;
   text-align: left;
   padding-bottom: 0.25rem;
   height: 4rem;

--- a/src/www/components/footer/Footer.scss
+++ b/src/www/components/footer/Footer.scss
@@ -1,7 +1,11 @@
 footer {
-  background-color: rgba($color: gray, $alpha: 0.05);
+  background-color: whitesmoke;
+  bottom: 0;
+  position: fixed;
   text-align: left;
   padding-bottom: 0.25rem;
+  height: 4rem;
+  width: 100%;
 
   .Divider {
     border: none;
@@ -32,12 +36,25 @@ footer {
 }
 
 @media only screen and(max-width: 550px) {
-  footer .Content {
-    flex-direction: column;
+  footer {
+    height: 6rem;
     
-    .Social_Media{
-      margin: 0;
-      padding: 0 1rem;
+    .Content {
+      flex-direction: column;
+  
+      p {
+        margin-bottom: 0.75rem;
+      }
+  
+      .Social_Media {
+        margin: 0;
+        padding: 0 1rem;
+  
+        > a > img {
+          margin-top: 0;
+          max-height: 25px;
+        }
+      }
     }
   }
 }

--- a/src/www/components/popup/ActionPopup.jsx
+++ b/src/www/components/popup/ActionPopup.jsx
@@ -249,7 +249,7 @@ class ActionPopup extends Component {
       actionDate: this.props.date || defDate,
       actionPicture: undefined,
       actionTeam:
-        this.props.organizer || teams.length > 0 ? teams[0] : undefined,
+        this.props.organizer || (teams.length > 0 ? teams[0] : undefined),
       actionId: "",
       actionLocation: this.props.location || initPosition,
       serverResponse: "",

--- a/src/www/components/popup/ActionPopup.jsx
+++ b/src/www/components/popup/ActionPopup.jsx
@@ -281,9 +281,8 @@ class ActionPopup extends Component {
       description,
       checkedCategories,
       serverResponse,
-      actionDate,
       actionLocation,
-      actionTeam,
+      teams,
     } = this.state;
 
     return (
@@ -339,7 +338,7 @@ class ActionPopup extends Component {
                       onChange={(opt) =>
                         this.setState({ actionTeam: opt.value })
                       }
-                      options={this.state.teams.map((t) => ({
+                      options={teams.map((t) => ({
                         value: t,
                         label: t.name,
                       }))}
@@ -380,7 +379,7 @@ class ActionPopup extends Component {
                     <div className="FormArea_content_map">
                       <Map
                         className="Map"
-                        center={this.state.actionLocation.coordinates}
+                        center={actionLocation.coordinates}
                         zoom={15}
                         onClick={(center, address) =>
                           this.setState({

--- a/src/www/components/popup/ActionPopup.jsx
+++ b/src/www/components/popup/ActionPopup.jsx
@@ -179,7 +179,7 @@ class ActionPopup extends Component {
       actionPicture,
     } = this.state;
     if (actionTeam === undefined) {
-      this.setState({
+      return this.setState({
         serverResponse: t("createaction.noteamerror"),
       });
     }

--- a/src/www/containers/actionprofile/ActionProfile.js
+++ b/src/www/containers/actionprofile/ActionProfile.js
@@ -34,7 +34,6 @@ export default connect(
           attendees: 0,
           categories: [],
           date: undefined,
-          isHost: false,
           location: {},
           name: "",
           organizer: "",
@@ -181,6 +180,8 @@ export default connect(
             attendees,
             categories,
             organizer,
+            openModal,
+            isHost,
           } = this.state;
 
           const actionPhoto = photo
@@ -191,13 +192,13 @@ export default connect(
             ? `/api/images/${organizer.photo}`
             : "/img/teaminfo/default.png";
 
-          const coordinates = this.state.location.coordinates;
+          const coordinates = location.coordinates;
 
           return (
             <div>
               <ActionPopup
                 allCategories={allCategories}
-                open={this.state.openModal}
+                open={openModal}
                 onClose={() => this.setState({ openModal: false })}
                 name={name}
                 description={description}
@@ -225,7 +226,7 @@ export default connect(
                       <div>
                         <h1 className="clamped">{name}</h1>
                         <p>{parseDate(date, t)}</p>
-                        {this.state.isHost ? (
+                        {isHost ? (
                           <button
                             children={t("actioninfo.edit")}
                             onClick={() => this.setState({ openModal: true })}

--- a/src/www/containers/actionspage/ActionsPage.jsx
+++ b/src/www/containers/actionspage/ActionsPage.jsx
@@ -97,14 +97,14 @@ export default connect(
                   <h3 className="clamped">{name}</h3>
                 </Link>
                 <div className="date">
-                  <span>{parseDate(date, t)}</span>
+                  <span className="clamped">{parseDate(date, t)}</span>
                 </div>
                 <a
                   href={location_link}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  <span>{location.name}</span>
+                  <span className="clamped">{location.name}</span>
                 </a>
                 <div className="description">
                   <p className="clamped">{description}</p>

--- a/src/www/containers/actionspage/ActionsPage.scss
+++ b/src/www/containers/actionspage/ActionsPage.scss
@@ -95,6 +95,7 @@
               margin-bottom: 0.2rem;
               margin-right: 0.8rem;
               padding-right: 1rem;
+              width: fit-content;
 
               &:hover {
                 color: rgb(96, 175, 233);

--- a/src/www/containers/actionspage/ActionsPage.scss
+++ b/src/www/containers/actionspage/ActionsPage.scss
@@ -44,7 +44,12 @@
       justify-content: center;
       list-style: none;
       margin: 0;
+      margin-top: 2rem;
       padding-left: 0;
+
+      > p {
+        padding-top: 1rem;
+      }
 
       > li {
         background-color: rgba($color: royalblue, $alpha: 0.3);
@@ -68,6 +73,7 @@
           > img {
             border-bottom-left-radius: 0.5rem;
             border-top-left-radius: 0.5rem;
+            object-fit: cover;
             height: 15rem;
             width: 20.5rem;
           }
@@ -135,60 +141,16 @@
         flex-wrap: wrap;
         justify-content: center;
         list-style: none;
-        padding-left: 1rem;
-        padding-top: 2rem;
         width: 100%;
 
         > li {
-          display: flex;
-          height: fit-content;
-          flex-direction: column;
-          list-style: none;
-          margin-bottom: 1rem;
-          margin-bottom: 2rem;
-          margin-left: 0.5rem;
-          margin-right: 0.5rem;
-          margin-top: 0rem;
+          margin: 1rem;
+          margin-left: 2rem;
+          margin-right: 0;
           width: 100%;
 
-          > .hidden_desc {
-            display: block;
-            margin-top: 2rem;
-            > p {
-              -webkit-line-clamp: 3;
-              font-size: 1rem;
-              padding-right: 1rem;
-            }
-          }
-
-          > div {
-            height: 6.5rem;
-            > a > h3 {
-              margin-left: 13rem;
-            }
-            > div > span {
-              margin-top: 0.5rem;
-              margin-left: 13rem;
-            }
-            > a > span {
-              margin-left: 13rem;
-            }
-            .description {
-              display: none;
-            }
-          }
-
-          > a {
-            display: contents;
-
-            > img {
-              border-radius: 0.5rem;
-              height: 8rem;
-              margin: 1rem;
-              object-fit: cover;
-              position: absolute;
-              width: 12rem;
-            }
+          > a > img {
+            width: 16rem;
           }
         }
       }
@@ -229,8 +191,6 @@
         flex-wrap: wrap;
         justify-content: center;
         list-style: none;
-        padding-left: 0rem;
-        padding-top: 2rem;
         width: 100%;
 
         > li {
@@ -239,7 +199,7 @@
           box-shadow: 0 0 10px 1px rgba($color: black, $alpha: 0.15);
           display: flex;
           flex-direction: column;
-          height: 23.5rem;
+          height: fit-content;
           list-style: none;
           margin-bottom: 1rem;
           margin-bottom: 2rem;

--- a/src/www/containers/actionspage/ActionsPage.scss
+++ b/src/www/containers/actionspage/ActionsPage.scss
@@ -144,13 +144,53 @@
         width: 100%;
 
         > li {
+          display: flex;
+          height: fit-content;
+          flex-direction: column;
+          list-style: none;
           margin: 1rem;
-          margin-left: 2rem;
+          margin-left: 1rem;
           margin-right: 0;
           width: 100%;
 
-          > a > img {
-            width: 16rem;
+          > .hidden_desc {
+            display: block;
+            margin-top: 2rem;
+            > p {
+              -webkit-line-clamp: 3;
+              font-size: 1rem;
+              padding-right: 1rem;
+            }
+          }
+
+          > div {
+            height: 6.5rem;
+            > a > h3 {
+              margin-left: 13rem;
+            }
+            > div > span {
+              margin-top: 0.5rem;
+              margin-left: 13rem;
+            }
+            > a > span {
+              margin-left: 13rem;
+            }
+            .description {
+              display: none;
+            }
+          }
+
+          > a {
+            display: contents;
+
+            > img {
+              border-radius: 0.5rem;
+              height: 8rem;
+              margin: 1rem;
+              object-fit: contain;
+              position: absolute;
+              width: 12rem;
+            }
           }
         }
       }

--- a/src/www/containers/authentication/Authentication.scss
+++ b/src/www/containers/authentication/Authentication.scss
@@ -4,13 +4,10 @@ $softBlack: rgba(
 );
 
 .Auth-page {
-  background-color: rgba(
-    $color: peachpuff,
-    $alpha: 0.1
-  ); // TODO: change to image
+  align-items: center;
+  background-color: rgba($color: peachpuff, $alpha: 0.1);
   display: flex;
   justify-content: center;
-  padding: 2rem;
 
   .Auth-panel {
     align-items: center;
@@ -21,7 +18,8 @@ $softBlack: rgba(
     display: flex;
     flex-direction: column;
     margin: 10vh 0;
-    padding: 4rem 0;
+    height: fit-content;
+    padding: 1.5rem 0;
     width: 50vw;
 
     .Auth-header {

--- a/src/www/containers/contactpage/ContactPage.scss
+++ b/src/www/containers/contactpage/ContactPage.scss
@@ -4,16 +4,15 @@
   align-items: center;
   background-image: url("/img/contact/newbackground.png");
   background-repeat: repeat;
-  background-size: cover;
+  background-size: 100% auto;
   display: flex;
   flex-direction: column;
-  padding: 2.75rem 0;
 
   > h2 {
     font-size: 3rem;
     font-weight: normal;
     margin-bottom: 0.5rem;
-    margin-top: 1rem;
+    margin-top: 2.5rem;
   }
 
   > h3 {

--- a/src/www/containers/dashboard/Dashboard.scss
+++ b/src/www/containers/dashboard/Dashboard.scss
@@ -113,7 +113,7 @@
     &_recommend {
       margin-top: 2rem;
 
-      li:not(:last-of-type) {
+      > ul > li:not(:last-of-type) {
         margin-bottom: 1rem;
       }
     }

--- a/src/www/containers/dashboard/Dashboard.scss
+++ b/src/www/containers/dashboard/Dashboard.scss
@@ -4,8 +4,8 @@
   background-color: rgba($color: lightgray, $alpha: 0.15);
   display: flex;
   flex-direction: row;
-  justify-content: space-evenly;
-  padding: 1rem 2rem;
+  justify-content: space-around;
+  padding: 0 2rem;
   text-align: left;
 
   ul {
@@ -28,6 +28,7 @@
 
   &_main {
     max-width: 70vw;
+    padding-top: 1rem;
     width: 100%;
 
     > div {
@@ -111,6 +112,10 @@
 
     &_recommend {
       margin-top: 2rem;
+
+      li:not(:last-of-type) {
+        margin-bottom: 1rem;
+      }
     }
   }
 
@@ -259,6 +264,7 @@
   .Dashboard {
     align-items: center;
     flex-direction: column;
+    justify-content: start;
 
     &_main {
       max-width: unset;
@@ -269,7 +275,7 @@
 
       > div {
         background-color: unset;
-        margin-top: 1rem;
+        margin: 1rem 0;
         width: calc(100vw - 8rem);
       }
 

--- a/src/www/containers/landingpage/LandingPage.scss
+++ b/src/www/containers/landingpage/LandingPage.scss
@@ -1,8 +1,7 @@
 .LandingPage {
-  margin-bottom: 2rem;
-  margin-top: -4rem;
-
   .Intro {
+    margin-top: -4rem;
+
     &_parallax {
       align-items: center;
       display: flex;
@@ -118,6 +117,8 @@
   }
 
   .Categories {
+    padding-bottom: 2rem;
+
     &_panel {
       flex-wrap: wrap;
     }

--- a/src/www/containers/settingspage/SettingsPage.scss
+++ b/src/www/containers/settingspage/SettingsPage.scss
@@ -6,7 +6,11 @@
   flex-direction: row;
   justify-content: center;
   margin: auto;
-  padding: 2rem;
+
+  > div {
+    margin-bottom: 2rem;
+    margin-top: 2rem;
+  }
 
   &_navigation {
     background-color: rgba($color: white, $alpha: 0.7);
@@ -67,6 +71,7 @@
     border: 1px solid $softBlack;
     box-shadow: 1px 1px 1rem $softBlack;
     margin-left: 2rem;
+    height: fit-content;
     padding: 1rem 4rem;
     text-align: left;
     width: 48rem;
@@ -192,13 +197,24 @@
 
     align-items: center;
     flex-direction: column;
+    justify-content: start;
+
+    > div {
+      margin: 0;
+
+      &:first-of-type {
+        margin-top: 2rem;
+      }
+
+      &:last-of-type {
+        margin-bottom: 2rem;
+      }
+    }
 
     &_navigation {
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
       border-bottom: none;
-      margin-bottom: 0;
-      margin-left: 0;
       width: calc(#{$contentWidth} + 5rem);
 
       &_header {

--- a/src/www/containers/teamprofile/TeamProfile.scss
+++ b/src/www/containers/teamprofile/TeamProfile.scss
@@ -2,6 +2,7 @@
   background-color: rgb(234, 237, 245);
   margin: auto;
   padding: 2rem 13vw;
+  min-height: 83vh;
 
   .TopPanel {
     background-color: rgba($color: white, $alpha: 0.7);

--- a/src/www/containers/teamprofile/TeamProfile.scss
+++ b/src/www/containers/teamprofile/TeamProfile.scss
@@ -191,8 +191,12 @@
         }
 
         > ul {
-          list-style: none;  
+          list-style: none;
           padding: 0;
+          
+          > li:not(:last-of-type) {
+            margin-bottom: 1rem;
+          }
         }
       }
     }

--- a/src/www/containers/userprofile/UserProfile.scss
+++ b/src/www/containers/userprofile/UserProfile.scss
@@ -2,7 +2,11 @@
   background-image: url("/img/profile/sky.jpg");
   display: flex;
   flex-direction: row;
-  padding: 4rem 8rem;
+  padding: 0 8rem;
+
+  > div {
+    padding-top: 4rem;
+  }
 
   .UserPanel {
     display: flex;
@@ -79,6 +83,7 @@
     }
 
     &_content {
+      margin-bottom: 4rem;
       margin-top: 1rem;
 
       > :not(.active) {
@@ -100,8 +105,7 @@
 
         > h3 {
           font-size: 1.5rem;
-          margin-bottom: 1rem;
-          margin-top: 2rem;
+          margin: 1rem 0;
           text-align: left;
         }
 
@@ -207,18 +211,17 @@
 
 @media only screen and(max-width: 1400px) {
   .ProfilePage {
-    padding: 4rem 2rem;
+    padding: initial 2rem;
   }
 }
 
 @media only screen and(max-width: 920px) {
   .ProfilePage {
     flex-direction: column;
-    padding: 2rem;
 
     .UserPanel {
       flex-direction: row;
-      padding: 1rem 0;
+      padding: 2rem 0;
       width: 100%;
 
       button {
@@ -233,6 +236,7 @@
 
     .Container {
       margin: 1rem 0;
+      padding-top: 0;
     }
   }
 }

--- a/src/www/date.js
+++ b/src/www/date.js
@@ -2,7 +2,15 @@ export function parseDate(date, t) {
   const d = new Date(date);
   const day = t("date.day." + d.getDay());
   const month = t("date.month." + d.getMonth());
+  const hours = d
+    .getUTCHours()
+    .toString()
+    .padStart(2, "0");
+  const mins = d
+    .getUTCMinutes()
+    .toString()
+    .padStart(2, "0");
+  const offset = "GMT"; // maybe make this dynamic in the future
 
-  return `${day}, ${d.getDate()} ${month} ${d.getFullYear()}, 
-      ${d.getUTCHours()}:${d.getUTCMinutes()}`;
+  return `${day}, ${d.getDate()} ${month} ${d.getFullYear()}, ${hours}:${mins} ${offset}`;
 }


### PR DESCRIPTION
## About
In this PR:

#### 1) I changed the minimum height of all pages to be at least as tall as the page.
This means that all the pages will look similar to each other, with no height differences.

#### 2) I added a placeholder in ActionCard when no categories are selected.
![with](https://user-images.githubusercontent.com/8458550/85422096-dd814f00-b57d-11ea-8291-fe428a11f91a.png)
![without](https://user-images.githubusercontent.com/8458550/85422225-09043980-b57e-11ea-999a-259c37189b84.png)

#### 3) I fixed a few issues with the ActionPopup.
a) We accidentally continued with the submission process even if a user had no teams selected, instead of stopping.
b) There was a slight issue with the reset function leading to no team being selected after closing and reopening.

#### 4) I allowed images for actions to be up to 1920x1080px.
This will make them look better in places like (1) mobile view in `/actions`, (2) background in `/actions/:id`.
Plus it's better for future-proofing, if we decide to change how these images appear.